### PR TITLE
AP_XRCE_Client: replace aliased types with equivalent primitives

### DIFF
--- a/libraries/AP_XRCE_Client/Idl/BatteryState.idl
+++ b/libraries/AP_XRCE_Client/Idl/BatteryState.idl
@@ -9,31 +9,31 @@ module sensor_msgs {
     module BatteryState_Constants {
       @verbatim (language="comment", text=
         "Constants are chosen to match the enums in the linux kernel" "\n"        "defined in include/linux/power_supply.h as of version 3.7" "\n"        "The one difference is for style reasons the constants are" "\n"        "all uppercase not mixed case." "\n"        "Power supply status constants")
-      const uint8 POWER_SUPPLY_STATUS_UNKNOWN = 0;
-      const uint8 POWER_SUPPLY_STATUS_CHARGING = 1;
-      const uint8 POWER_SUPPLY_STATUS_DISCHARGING = 2;
-      const uint8 POWER_SUPPLY_STATUS_NOT_CHARGING = 3;
-      const uint8 POWER_SUPPLY_STATUS_FULL = 4;
+      const octet POWER_SUPPLY_STATUS_UNKNOWN = 0;
+      const octet POWER_SUPPLY_STATUS_CHARGING = 1;
+      const octet POWER_SUPPLY_STATUS_DISCHARGING = 2;
+      const octet POWER_SUPPLY_STATUS_NOT_CHARGING = 3;
+      const octet POWER_SUPPLY_STATUS_FULL = 4;
       @verbatim (language="comment", text=
         "Power supply health constants")
-      const uint8 POWER_SUPPLY_HEALTH_UNKNOWN = 0;
-      const uint8 POWER_SUPPLY_HEALTH_GOOD = 1;
-      const uint8 POWER_SUPPLY_HEALTH_OVERHEAT = 2;
-      const uint8 POWER_SUPPLY_HEALTH_DEAD = 3;
-      const uint8 POWER_SUPPLY_HEALTH_OVERVOLTAGE = 4;
-      const uint8 POWER_SUPPLY_HEALTH_UNSPEC_FAILURE = 5;
-      const uint8 POWER_SUPPLY_HEALTH_COLD = 6;
-      const uint8 POWER_SUPPLY_HEALTH_WATCHDOG_TIMER_EXPIRE = 7;
-      const uint8 POWER_SUPPLY_HEALTH_SAFETY_TIMER_EXPIRE = 8;
+      const octet POWER_SUPPLY_HEALTH_UNKNOWN = 0;
+      const octet POWER_SUPPLY_HEALTH_GOOD = 1;
+      const octet POWER_SUPPLY_HEALTH_OVERHEAT = 2;
+      const octet POWER_SUPPLY_HEALTH_DEAD = 3;
+      const octet POWER_SUPPLY_HEALTH_OVERVOLTAGE = 4;
+      const octet POWER_SUPPLY_HEALTH_UNSPEC_FAILURE = 5;
+      const octet POWER_SUPPLY_HEALTH_COLD = 6;
+      const octet POWER_SUPPLY_HEALTH_WATCHDOG_TIMER_EXPIRE = 7;
+      const octet POWER_SUPPLY_HEALTH_SAFETY_TIMER_EXPIRE = 8;
       @verbatim (language="comment", text=
         "Power supply technology (chemistry) constants")
-      const uint8 POWER_SUPPLY_TECHNOLOGY_UNKNOWN = 0;
-      const uint8 POWER_SUPPLY_TECHNOLOGY_NIMH = 1;
-      const uint8 POWER_SUPPLY_TECHNOLOGY_LION = 2;
-      const uint8 POWER_SUPPLY_TECHNOLOGY_LIPO = 3;
-      const uint8 POWER_SUPPLY_TECHNOLOGY_LIFE = 4;
-      const uint8 POWER_SUPPLY_TECHNOLOGY_NICD = 5;
-      const uint8 POWER_SUPPLY_TECHNOLOGY_LIMN = 6;
+      const octet POWER_SUPPLY_TECHNOLOGY_UNKNOWN = 0;
+      const octet POWER_SUPPLY_TECHNOLOGY_NIMH = 1;
+      const octet POWER_SUPPLY_TECHNOLOGY_LION = 2;
+      const octet POWER_SUPPLY_TECHNOLOGY_LIPO = 3;
+      const octet POWER_SUPPLY_TECHNOLOGY_LIFE = 4;
+      const octet POWER_SUPPLY_TECHNOLOGY_NICD = 5;
+      const octet POWER_SUPPLY_TECHNOLOGY_LIMN = 6;
     };
     struct BatteryState {
       std_msgs::msg::Header header;
@@ -68,15 +68,15 @@ module sensor_msgs {
 
       @verbatim (language="comment", text=
         "The charging status as reported. Values defined above")
-      uint8 power_supply_status;
+      octet power_supply_status;
 
       @verbatim (language="comment", text=
         "The battery health metric. Values defined above")
-      uint8 power_supply_health;
+      octet power_supply_health;
 
       @verbatim (language="comment", text=
         "The battery chemistry. Values defined above")
-      uint8 power_supply_technology;
+      octet power_supply_technology;
 
       @verbatim (language="comment", text=
         "True if the battery is present")

--- a/libraries/AP_XRCE_Client/Idl/NavSatFix.idl
+++ b/libraries/AP_XRCE_Client/Idl/NavSatFix.idl
@@ -11,10 +11,10 @@ module sensor_msgs {
     module NavSatFix_Constants {
       @verbatim (language="comment", text=
         "If the covariance of the fix is known, fill it in completely. If the" "\n"        "GPS receiver provides the variance of each measurement, put them" "\n"        "along the diagonal. If only Dilution of Precision is available," "\n"        "estimate an approximate covariance from that.")
-      const uint8 COVARIANCE_TYPE_UNKNOWN = 0;
-      const uint8 COVARIANCE_TYPE_APPROXIMATED = 1;
-      const uint8 COVARIANCE_TYPE_DIAGONAL_KNOWN = 2;
-      const uint8 COVARIANCE_TYPE_KNOWN = 3;
+      const octet COVARIANCE_TYPE_UNKNOWN = 0;
+      const octet COVARIANCE_TYPE_APPROXIMATED = 1;
+      const octet COVARIANCE_TYPE_DIAGONAL_KNOWN = 2;
+      const octet COVARIANCE_TYPE_KNOWN = 3;
     };
     @verbatim (language="comment", text=
       "Navigation Satellite fix for any Global Navigation Satellite System" "\n"
@@ -59,9 +59,9 @@ module sensor_msgs {
         "" "\n"
         "Beware: this coordinate system exhibits singularities at the poles.")
       @unit (value="m^2")
-      double__9 position_covariance;
+      double position_covariance[9];
 
-      uint8 position_covariance_type;
+      octet position_covariance_type;
     };
   };
 };

--- a/libraries/AP_XRCE_Client/Idl/NavSatStatus.idl
+++ b/libraries/AP_XRCE_Client/Idl/NavSatStatus.idl
@@ -8,16 +8,16 @@ module sensor_msgs {
     module NavSatStatus_Constants {
       @verbatim (language="comment", text=
         "unable to fix position")
-      const int8 STATUS_NO_FIX = -1;
+      const char STATUS_NO_FIX = -1;
       @verbatim (language="comment", text=
         "unaugmented fix")
-      const int8 STATUS_FIX = 0;
+      const char STATUS_FIX = 0;
       @verbatim (language="comment", text=
         "with satellite-based augmentation")
-      const int8 STATUS_SBAS_FIX = 1;
+      const char STATUS_SBAS_FIX = 1;
       @verbatim (language="comment", text=
         "with ground-based augmentation")
-      const int8 STATUS_GBAS_FIX = 2;
+      const char STATUS_GBAS_FIX = 2;
       @verbatim (language="comment", text=
         "Bits defining which Global Navigation Satellite System signals were" "\n"        "used by the receiver.")
       const uint16 SERVICE_GPS = 1;
@@ -34,7 +34,7 @@ module sensor_msgs {
       "type and the last time differential corrections were received.  A" "\n"
       "fix is valid when status >= STATUS_FIX.")
     struct NavSatStatus {
-      int8 status;
+      char status;
 
       uint16 service;
     };

--- a/libraries/AP_XRCE_Client/Idl/Vector3.idl
+++ b/libraries/AP_XRCE_Client/Idl/Vector3.idl
@@ -1,0 +1,22 @@
+// generated from rosidl_adapter/resource/msg.idl.em
+// with input from geometry_msgs/msg/Vector3.msg
+// generated code does not contain a copyright notice
+
+
+module geometry_msgs {
+  module msg {
+    @verbatim (language="comment", text=
+      "This represents a vector in free space.")
+    struct Vector3 {
+      @verbatim (language="comment", text=
+        "This is semantically different than a point." "\n"
+        "A vector is always anchored at the origin." "\n"
+        "When a transform is applied to a vector, only the rotational component is applied.")
+      double x;
+
+      double y;
+
+      double z;
+    };
+  };
+};

--- a/libraries/AP_XRCE_Client/wscript
+++ b/libraries/AP_XRCE_Client/wscript
@@ -46,7 +46,11 @@ def build(bld):
     config_h_nodes = [bld.bldnode.find_or_declare(h[:-3]) for h in config_h_in]
 
     gen_path = "libraries/AP_XRCE_Client"
-    extra_bld_inc = ['modules/Micro-CDR/include', 'modules/Micro-XRCE-DDS-Client/include', gen_path]
+    extra_bld_inc = [
+        'modules/Micro-CDR/include',\
+        'modules/Micro-XRCE-DDS-Client/include',
+        gen_path,
+    ]
     for inc in extra_bld_inc:
         bld.env.INCLUDES += [bld.bldnode.find_or_declare(inc).abspath()]
 
@@ -68,7 +72,21 @@ def build(bld):
         )
 
     # temporary whitelist while include issue is sorted out
-    whitelist = ['Duration.idl', 'Time.idl']
+    whitelist = [
+      'BatteryState.idl',
+      'Duration.idl',
+      'Header.idl',
+      'NavSatFix.idl', 
+      'NavSatStatus.idl',
+      'Point.idl',
+      'Pose.idl',
+      # 'PoseStamped.idl',
+      'Quaternion.idl',
+      'Time.idl',
+      'Twist.idl',
+      # 'TwistStamped.idl',
+      'Vector3.idl',
+    ]
 
     idl_files = bld.srcnode.ant_glob('libraries/AP_XRCE_Client/Idl/**/*.idl')
     for idl in idl_files:


### PR DESCRIPTION
A few commits that get all but two of the message types working. 